### PR TITLE
Make charting-service timezone aware

### DIFF
--- a/charting_service/charts/__init__.py
+++ b/charting_service/charts/__init__.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import Union
 import pathlib
 import pymysql
@@ -6,29 +7,32 @@ from charts.generation import generate_charts
 from charts.amountsource import CaloriesAmountSource, HoursOfWorkAmountSource, SpendingsAmountSource
 import config
 
-def generate_calories_charts(output_timestamp: Union[str, None]):
+def generate_calories_charts(day: date, output_timestamp: Union[str, None]):
     con = pymysql.connect(host=config.db_host,user=config.db_user,passwd=config.db_password,db=config.db_name)
     calories_amount_source = CaloriesAmountSource(con)
 
     output_dir = pathlib.Path.cwd() / 'generated/calories'
-    generate_charts(output_dir, calories_amount_source, output_timestamp)
+
+    generate_charts(output_dir, calories_amount_source, day, output_timestamp)
 
     con.close()
 
-def generate_hoursofwork_charts(output_timestamp: Union[str, None]):
+def generate_hoursofwork_charts(day: date, output_timestamp: Union[str, None]):
     con = pymysql.connect(host=config.db_host,user=config.db_user,passwd=config.db_password,db=config.db_name)
     hoursofwork_amount_source = HoursOfWorkAmountSource(con)
 
     output_dir = pathlib.Path.cwd() / 'generated/hoursofwork'
-    generate_charts(output_dir, hoursofwork_amount_source, output_timestamp, only_monday_to_friday=True)
+
+    generate_charts(output_dir, hoursofwork_amount_source, day, output_timestamp, only_monday_to_friday=True)
 
     con.close()
 
-def generate_spendings_charts(output_timestamp: Union[str, None]):
+def generate_spendings_charts(day: date, output_timestamp: Union[str, None]):
     con = pymysql.connect(host=config.db_host,user=config.db_user,passwd=config.db_password,db=config.db_name)
     spendings_amount_source = SpendingsAmountSource(con)
 
     output_dir = pathlib.Path.cwd() / 'generated/spendings'
-    generate_charts(output_dir, spendings_amount_source, output_timestamp)
+
+    generate_charts(output_dir, spendings_amount_source, day, output_timestamp)
 
     con.close()

--- a/charting_service/charts/generation.py
+++ b/charting_service/charts/generation.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from charts.amountsource import AmountSource
+from matplotlib.ticker import AutoMinorLocator
+from typing import Union
 import calendar
+import config
 import datetime
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -11,9 +15,6 @@ import os
 import pandas as pd
 import pathlib
 import time
-from matplotlib.ticker import AutoMinorLocator
-from typing import Union
-from charts.amountsource import AmountSource
 
 max_categories_7days = 6  # max number of categories to show for 7 days plot
 max_categories_progress = 5  # max number of categories to show for progress plot
@@ -25,7 +26,7 @@ style.use(plot_style)
 def generate_charts(output_dir: pathlib.Path,
                     amount_source: AmountSource,
                     output_timestamp: Union[str, None] = None,
-                    day: datetime.date = datetime.date.today(),
+                    day: datetime.date = datetime.datetime.now(config.timezone).date(),
                     only_monday_to_friday: bool = False):
     timestamp_outputpath = output_dir / 'timestamp'
     chart_7days_outputpath = output_dir / 'chart_7days.png'

--- a/charting_service/charts/generation.py
+++ b/charting_service/charts/generation.py
@@ -5,7 +5,6 @@ from charts.amountsource import AmountSource
 from matplotlib.ticker import AutoMinorLocator
 from typing import Union
 import calendar
-import config
 import datetime
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -25,8 +24,8 @@ style.use(plot_style)
 
 def generate_charts(output_dir: pathlib.Path,
                     amount_source: AmountSource,
+                    day: datetime.date,
                     output_timestamp: Union[str, None] = None,
-                    day: datetime.date = datetime.datetime.now(config.timezone).date(),
                     only_monday_to_friday: bool = False):
     timestamp_outputpath = output_dir / 'timestamp'
     chart_7days_outputpath = output_dir / 'chart_7days.png'
@@ -47,9 +46,9 @@ def generate_charts(output_dir: pathlib.Path,
         os.makedirs(output_dir)
 
 # Fetch from database.
-    daily_goal = amount_source.daily_goal()
     amount_categories = amount_source.categories()
-    amounts_last_31_days = amount_source.amounts_last_31_days()
+    daily_goal = amount_source.daily_goal(day)
+    amounts_last_31_days = amount_source.amounts_last_31_days(day)
 
 # Find out relevant days in this month/week and compute monthly goal.
     relevant_days_this_month = sum(1 for x in range(calendar.monthrange(day.year, day.month)[1])\

--- a/charting_service/config.py
+++ b/charting_service/config.py
@@ -1,12 +1,14 @@
-# set up relevant variables
-import pathlib
 import configparser
+import pathlib
+import pytz
 
 file_name = pathlib.Path.cwd() / 'config' / 'config.ini'
 
 # set up database login data
 parser = configparser.ConfigParser()
 parser.read(str(file_name))
+
+timezone=pytz.timezone("Europe/Zurich")
 
 db_host = parser.get('DB', 'host').strip('"')
 db_name = parser.get('DB', 'name').strip('"')

--- a/charting_service/config.py
+++ b/charting_service/config.py
@@ -8,7 +8,8 @@ file_name = pathlib.Path.cwd() / 'config' / 'config.ini'
 parser = configparser.ConfigParser()
 parser.read(str(file_name))
 
-timezone=pytz.timezone("Europe/Zurich")
+timezone_name = parser.get('Localization', 'timezone').strip('"')
+timezone = pytz.timezone(timezone_name)
 
 db_host = parser.get('DB', 'host').strip('"')
 db_name = parser.get('DB', 'name').strip('"')

--- a/charting_service/server.py
+++ b/charting_service/server.py
@@ -7,6 +7,7 @@ from rocketry.conds import daily
 from typing import Union
 import asyncio
 import charts
+import config
 
 class ChartType(str, Enum):
     calories = "calories"
@@ -17,7 +18,7 @@ class ChartType(str, Enum):
 chart_generation_executor = ProcessPoolExecutor()
 
 # We use rocketry to re-generate the charts at midnight.
-chart_generation_scheduler = Rocketry(execution="async")
+chart_generation_scheduler = Rocketry(execution="async", timezone=config.timezone)
 
 @chart_generation_scheduler.task(daily.at("00:00"))
 def generate_all_charts():

--- a/config/config.ini.sample
+++ b/config/config.ini.sample
@@ -5,6 +5,8 @@
 ; Do not forget to give the grants on the database with respect to hosts from
 ; the `172.%` subnet if on Linux. To do so, configure mysql's `bind-address`
 ; setting.
+[Localization]
+timezone = UTC
 
 [DB]
 host = 172.17.0.1

--- a/todo.md
+++ b/todo.md
@@ -19,8 +19,6 @@
 
 # Backend
 
-- Enable setting a timezone (relevant for automatic generation of charts) in the charting-service container.
-
 - Reimplement the API in something other than PHP. E.g. Rust with Axum.
 
 - Maybe use PostgreSQL rather than MySQL/MariaDB, as the containerized version is much better.


### PR DESCRIPTION
Read timezone from config.ini and use it when
* re-building charts at midnight,
* determining amounts for last 31 days, and
* determining for which day to create the charts.